### PR TITLE
 changed the example.env file to leave LANGSMITH_TRACING unset with i…

### DIFF
--- a/example.env
+++ b/example.env
@@ -10,7 +10,8 @@ GOOGLE_API_KEY='your_google_api_key_here'
 
 # Optional for evaluation and tracing
 LANGSMITH_API_KEY='your_langsmith_api_key_here'
-LANGSMITH_TRACING=true
+# uncomment to set tracing to true when you set up your LangSmith account
+# LANGSMITH_TRACING=true
 LANGSMITH_PROJECT=lca-lc-foundation
 # Uncomment the following if you are on the EU instance:
 #LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com


### PR DESCRIPTION
 changed the example.env file to leave LANGSMITH_TRACING unset with instructions to set it true if they setup an account. This prevents an 'Failed to send compressed multipart ingest: langsmith.utils.LangSmithError: Failed to POST ' error that is the result of tracing with a bad key
 
 