### PR TITLE
 changed the google model to gemini-2.5-flash-lite. If you were using…

### DIFF
--- a/notebooks/module-1/1.1_foundational_models.ipynb
+++ b/notebooks/module-1/1.1_foundational_models.ipynb
@@ -129,7 +129,7 @@
    "source": [
     "from langchain_google_genai import ChatGoogleGenerativeAI\n",
     "\n",
-    "model = ChatGoogleGenerativeAI(model=\"gemini-3-pro-preview\")\n",
+    "model = ChatGoogleGenerativeAI(model=\"gemini-2.5-flash-lite\")\n",
     "\n",
     "response = model.invoke(\"What's the capital of the Moon?\")\n",
     "print(response.content)"
@@ -267,7 +267,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -281,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
… the free keys from google, you would get resource exhaust. This smaller model works well.