### PR TITLE
Fix HITL example: force tool call to trigger interrupt

### DIFF
--- a/notebooks/module-3/3.3_hitl.ipynb
+++ b/notebooks/module-3/3.3_hitl.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "response = agent.invoke(\n",
     "    {\n",
-    "        \"messages\": [HumanMessage(content=\"Please read my email and send a response.\")],\n",
+    "        \"messages\": [HumanMessage(content=\"Please read my email and send a response immediately. Send the reply now in the same thread.\")],\n",
     "        \"email\": \"Hi Seán, I'm going to be late for our meeting tomorrow. Can we reschedule? Best, John.\"\n",
     "    },\n",
     "    config=config\n",


### PR DESCRIPTION
This PR updates the HITL example in Module 3 to ensure the human-in-the-loop interrupt is reliably triggered.

Previously, the AIMessage was pre-populated (i.e., not empty), which allowed the model to ask follow-up questions-
such as “Here are two options, which one should I send?”-and prevented the protected tool from being called, so no interrupt occurred.

The prompt has now been revised to explicitly enforce execution of the sensitive action. A brief markdown note clarifies that HITL interrupts only occur when a protected tool call is actually attempted.
<img width="1350" height="908" alt="screenshot_human_in_the_loop" src="https://github.com/user-attachments/assets/966a87f9-1f67-480d-8a20-5f6762fd408f" />

No changes were made to the agent state or middleware logic.