### PR TITLE
Enhancements to the check script env_utils.py and README additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,18 @@ cp example.env .env
 
 Edit the .env file to include the keys below. [More info](#model-providers)
 ```bash
-# Required for model usage
+# Required
 OPENAI_API_KEY='your_openai_api_key_here'
 TAVILY_API_KEY='your_tavily_api_key_here'
 
-# optional, only used in Lesson 1 once
+# optional, only used in Module1, Lesson 1 once
 ANTHROPIC_API_KEY='your_anthropic_api_key_here'
 GOOGLE_API_KEY='your_google_api_key_here'
 
 # Optional for evaluation and tracing
 LANGSMITH_API_KEY='your_langsmith_api_key_here'
-LANGSMITH_TRACING=true
+# uncomment to set tracing to true when you set up your LangSmith account
+#LANGSMITH_TRACING=true
 LANGSMITH_PROJECT=lca-lc-foundation
 # Uncomment the following if you are on the EU instance:
 #LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com
@@ -73,7 +74,7 @@ pip install -r requirements.txt
 
 ### Quick Start Verification
 
-After completing the Setup section, you can run this command to verify your environment:
+After completing the Setup section, we recommend you run this command to verify your environment:
 
 <details open>
 <summary>Using uv</summary>
@@ -91,6 +92,62 @@ uv run python env_utils.py
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 python env_utils.py
 ```
+
+</details>
+
+**What the verification checks:**
+- ✅ Python executable location and version (must be >=3.12, <3.14)
+- ✅ Virtual environment is properly activated
+- ✅ Required packages are installed with correct versions
+- ✅ Packages are in the correct Python version's site-packages
+- ✅ Environment variables (API keys) are properly configured
+
+**Configuration Issues and Solutions:**
+
+<details>
+<summary>ImportError when running env_utils.py</summary>
+
+If you see an error like `ModuleNotFoundError: No module named 'dotenv'`, you're likely running Python outside the virtual environment.
+
+**Solution:**
+- Use `uv run python env_utils.py` (recommended), or
+- Activate the virtual environment first:
+  - macOS/Linux: `source .venv/bin/activate`
+  - Windows: `.venv\Scripts\activate`
+
+</details>
+
+<details>
+<summary>Environment Variable Conflicts</summary>
+
+If you see a warning about "ENVIRONMENT VARIABLE CONFLICTS DETECTED", you have API keys set in your system environment that differ from your .env file. Since `load_dotenv()` doesn't override existing variables by default, your system values will be used.
+
+**Solutions:**
+1. Unset the conflicting system environment variables (commands provided in warning)
+2. Use `load_dotenv(override=True)` in your notebooks to force .env values to take precedence
+3. Update your .env file to match your system environment
+
+</details>
+
+<details>
+<summary>LangSmith Tracing Errors</summary>
+
+If you see "LANGSMITH_TRACING is enabled but LANGSMITH_API_KEY still has the example/placeholder value", you need to either:
+1. Set a valid LangSmith API key in your .env file, or
+2. Comment out or set `LANGSMITH_TRACING=false` in your .env file
+
+Note: LangSmith is optional for evaluation and tracing. The course works without it.
+
+</details>
+
+<details>
+<summary>Wrong Python Version</summary>
+
+If you see a warning about Python version not satisfying requirements, you need Python >=3.12 and <3.14.
+
+**Solution:**
+- If using `uv`: Run `uv sync` which will automatically install the correct Python version
+- If using pip: Install Python 3.12 or 3.13 using [pyenv](#python-virtual-environments) or from [python.org](https://www.python.org/downloads/)
 
 </details>
 
@@ -147,7 +204,7 @@ This repository contains three Modules that serve as introductions to many of La
 
 ## 📖 Related Resources
 
-### Python Virtual Environments 
+### Python Virtual Environments
 
 Managing your Python version is often best done with virtual environments. This allows you to select a Python version for the course independent of the system Python version.
 
@@ -190,14 +247,19 @@ Tavily is a search provider that returns search results in an LLM-friendly way. 
 
 <img width="600" alt="LangSmith API Keys" src="https://github.com/user-attachments/assets/2e916b2d-e3b0-4c59-a178-c5818604b8fe" />
 
-- Update your .env file you created with your new LangSmith API Key.
+- Update the .env file you created with your new LangSmith API Key.
+- Check that LANGSMITH_TRACING is uncommented and set to true.
 
 For more information on LangSmith, see our docs [here](https://docs.langchain.com/langsmith/home).
+
+**Note:** If you enable LangSmith tracing by setting `LANGSMITH_TRACING=true` in your .env file, make sure you have a valid `LANGSMITH_API_KEY` set. The environment verification script (`env_utils.py`) will warn you if tracing is enabled without a valid key.
 
 ### Environment Variables
 
 This course uses the [dotenv](https://pypi.org/project/python-dotenv) module to read key-value pairs from the .env file and set them in the environment in the Jupyter notebook. They do not need to be set globally in your system environment.
 
+**Note:** If you have API keys already set in your system environment, they may conflict with the ones in your .env file. The `env_utils.py` verification script will detect and warn you about such conflicts. By default, `load_dotenv()` does not override existing environment variables.
+
 ### Development Environment
 
-The course uses [Jupyter](https://jupyter.org/) notebooks. Jupyter is installed and can be run as described above. Jupyter notebooks can also be edited and run in VSCode or other VSCode variants such as Windsurf or Cursor.  
+The course uses [Jupyter](https://jupyter.org/) notebooks. Jupyter is installed and can be run as described above. Jupyter notebooks can also be edited and run in VSCode or other VSCode variants such as Windsurf or Cursor.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Welcome to LangChain Academy's Introduction to LangChain course!
 
 ### Prerequisites
 
-- The Chrome browser is recommended
-- Ensure you're using Python >=3.12, <3.14 [More info](#python-virtual-environments)
+- The [Chrome](https://www.google.com/chrome/) browser is recommended
+- [git](https://git-scm.com/install/) is recommended
 - A package/project manager: [uv](https://docs.astral.sh/uv/) (recommended) or [pip](https://pypi.org/project/pip/)
     - note: `uv` is also required in Module 2, Lesson 1 to run the MCP server with `uvx`
-
+- The course requires Python >=3.12, <3.14  If you use `uv`, it will take care of this for you. [More info](#python-virtual-environments)
 
 ### Installation
 
@@ -31,7 +31,7 @@ Make a copy of example.env
 cp example.env .env
 ```
 
-Edit the .env file to include the keys below. [More info](#model-providers)
+Edit the .env file to include the keys below for [Models](#model-providers) and optionally [LangSmith](#getting-started-with-langsmith)
 ```bash
 # Required
 OPENAI_API_KEY='your_openai_api_key_here'
@@ -74,7 +74,7 @@ pip install -r requirements.txt
 
 ### Quick Start Verification
 
-After completing the Setup section, we recommend you run this command to verify your environment:
+After completing the Setup section, we recommend you run the following command to verify your environment.  [More Info](#environment-verification)
 
 <details open>
 <summary>Using uv</summary>
@@ -92,62 +92,6 @@ uv run python env_utils.py
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 python env_utils.py
 ```
-
-</details>
-
-**What the verification checks:**
-- ✅ Python executable location and version (must be >=3.12, <3.14)
-- ✅ Virtual environment is properly activated
-- ✅ Required packages are installed with correct versions
-- ✅ Packages are in the correct Python version's site-packages
-- ✅ Environment variables (API keys) are properly configured
-
-**Configuration Issues and Solutions:**
-
-<details>
-<summary>ImportError when running env_utils.py</summary>
-
-If you see an error like `ModuleNotFoundError: No module named 'dotenv'`, you're likely running Python outside the virtual environment.
-
-**Solution:**
-- Use `uv run python env_utils.py` (recommended), or
-- Activate the virtual environment first:
-  - macOS/Linux: `source .venv/bin/activate`
-  - Windows: `.venv\Scripts\activate`
-
-</details>
-
-<details>
-<summary>Environment Variable Conflicts</summary>
-
-If you see a warning about "ENVIRONMENT VARIABLE CONFLICTS DETECTED", you have API keys set in your system environment that differ from your .env file. Since `load_dotenv()` doesn't override existing variables by default, your system values will be used.
-
-**Solutions:**
-1. Unset the conflicting system environment variables (commands provided in warning)
-2. Use `load_dotenv(override=True)` in your notebooks to force .env values to take precedence
-3. Update your .env file to match your system environment
-
-</details>
-
-<details>
-<summary>LangSmith Tracing Errors</summary>
-
-If you see "LANGSMITH_TRACING is enabled but LANGSMITH_API_KEY still has the example/placeholder value", you need to either:
-1. Set a valid LangSmith API key in your .env file, or
-2. Comment out or set `LANGSMITH_TRACING=false` in your .env file
-
-Note: LangSmith is optional for evaluation and tracing. The course works without it.
-
-</details>
-
-<details>
-<summary>Wrong Python Version</summary>
-
-If you see a warning about Python version not satisfying requirements, you need Python >=3.12 and <3.14.
-
-**Solution:**
-- If using `uv`: Run `uv sync` which will automatically install the correct Python version
-- If using pip: Install Python 3.12 or 3.13 using [pyenv](#python-virtual-environments) or from [python.org](https://www.python.org/downloads/)
 
 </details>
 
@@ -171,7 +115,6 @@ jupyter lab
 ```
 
 </details>
-
 
 ## 📚 Lessons
 This repository contains three Modules that serve as introductions to many of LangChain's most-used features.
@@ -234,7 +177,7 @@ pip install -r requirements.txt
 If you don't have an OpenAI API key, you can sign up [here](https://openai.com/index/openai-api/). The course primarily uses gpt-5-nano which is very inexpensive.
 You may also obtain additional API keys for [Anthropic](https://console.anthropic.com) or [Google](https://docs.langchain.com/oss/python/integrations/providers/google). These models are only used in the first lesson.
 
-This course has been created using particular models and model providers.  You can use other providers, but you will need to update the API keys in the .env file and make some necessary code changes. LangChain supports many chat model providers [here](https://docs.langchain.com/oss/python/integrations/providers/all_providers).
+This course has been created using particular models and model providers.  You can use other providers, but you will need to update the API keys in the .env file and make some necessary code changes. LangChain supports many chat model providers. [More Info](https://docs.langchain.com/oss/python/integrations/providers/all_providers).
 
 Tavily is a search provider that returns search results in an LLM-friendly way. They have a generous free tier. [Tavily](https://tavily.com)
 
@@ -256,10 +199,69 @@ For more information on LangSmith, see our docs [here](https://docs.langchain.co
 
 ### Environment Variables
 
-This course uses the [dotenv](https://pypi.org/project/python-dotenv) module to read key-value pairs from the .env file and set them in the environment in the Jupyter notebook. They do not need to be set globally in your system environment.
+This course uses the [dotenv](https://pypi.org/project/python-dotenv) module to read key-value pairs from the .env file and set them in the environment in the Jupyter notebooks. They do not need to be set globally in your system environment.
 
 **Note:** If you have API keys already set in your system environment, they may conflict with the ones in your .env file. The `env_utils.py` verification script will detect and warn you about such conflicts. By default, `load_dotenv()` does not override existing environment variables.
 
+### Environment Verification
+
+**What the verification procedure checks:**
+- ✅ Python executable location and version (must be >=3.12, <3.14)
+- ✅ Virtual environment is properly activated
+- ✅ Required packages are installed with correct versions
+- ✅ Packages are in the correct Python version's site-packages
+- ✅ Environment variables (API keys) are properly configured
+
+**Configuration Issues and Solutions:**
+
+<details>
+<summary>ImportError when running env_utils.py</summary>
+
+If you see an error like `ModuleNotFoundError: No module named 'dotenv'`, you're likely running Python outside the virtual environment.
+
+**Solution:**
+- Use `uv run python env_utils.py` (recommended), or
+- Activate the virtual environment first:
+  - macOS/Linux: `source .venv/bin/activate`
+  - Windows: `.venv\Scripts\activate`
+
+</details>
+
+<details>
+<summary>Environment Variable Conflicts</summary>
+
+If you see a warning about "ENVIRONMENT VARIABLE CONFLICTS DETECTED", you have API keys set in your system environment that differ from your .env file. Since `load_dotenv()` doesn't override existing variables by default, your system values will be used.
+
+**Solutions:**
+1. Do nothing and accept the system environment variable value
+2. Unset the conflicting system environment variables for this shell session (commands provided in warning)
+3. Use `load_dotenv(override=True)` in your notebooks to force .env values to take precedence
+4. Update your .env file or shell init so the values are in agreement
+
+</details>
+
+<details>
+<summary>LangSmith Tracing Errors</summary>
+
+If you see "LANGSMITH_TRACING is enabled but LANGSMITH_API_KEY still has the example/placeholder value", you need to either:
+1. Set a valid LangSmith API key in your .env file, or
+2. Comment out or set `LANGSMITH_TRACING=false` in your .env file
+
+Note: LangSmith is optional for evaluation and tracing. The course works without it.
+
+</details>
+
+<details>
+<summary>Wrong Python Version</summary>
+
+If you see a warning about Python version not satisfying requirements, you need Python >=3.12 and <3.14.
+
+**Solution:**
+- If using `uv`: Run `uv sync` which will automatically install the correct Python version
+- If using pip: Install Python 3.12 or 3.13 using [pyenv](#python-virtual-environments) or from [python.org](https://www.python.org/downloads/)
+
+</details>
+
 ### Development Environment
 
-The course uses [Jupyter](https://jupyter.org/) notebooks. Jupyter is installed and can be run as described above. Jupyter notebooks can also be edited and run in VSCode or other VSCode variants such as Windsurf or Cursor.
+The course uses [Jupyter](https://jupyter.org/) notebooks. The Jupyter package is installed in the virtual environment and can be run as described above. Jupyter notebooks can also be edited and run in VSCode or other VSCode variants such as Windsurf or Cursor.

--- a/env_utils.py
+++ b/env_utils.py
@@ -3,18 +3,246 @@
 # packages loaded, python and or node installed and api keys available
 # it references the pyproject.toml file and example.env for requirements
 
+# ========== STANDARD LIBRARY IMPORTS ONLY (no external dependencies) ==========
 import os
 import sys
 import shutil
+import re
 from pathlib import Path
-from dotenv import dotenv_values, load_dotenv
 
-def summarize_value(value: str) -> str:
-    """Return masked form: ****last4 or boolean string."""
+
+# ========== EARLY PYTHON ENVIRONMENT DIAGNOSTICS ==========
+def check_python_executable_and_version():
+    """
+    Check Python executable location and version BEFORE attempting any external imports.
+    This ensures students get helpful diagnostics even if imports fail.
+
+    Returns: tuple (success: bool, python_version_tuple, issues: list)
+    """
+    issues = []
+    executable = Path(sys.executable).resolve()
+    py_version = sys.version_info
+    py_version_str = f"{py_version.major}.{py_version.minor}.{py_version.micro}"
+
+    print("=" * 70)
+    print("PYTHON ENVIRONMENT DIAGNOSTICS")
+    print("=" * 70)
+    print(f"Python executable: {executable}")
+    print(f"Python version: {py_version_str}")
+    print(f"Platform: {sys.platform}")
+    print()
+
+    # Check if running in a virtual environment
+    in_venv = hasattr(sys, 'real_prefix') or (
+        hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
+    )
+
+    # Check if executable is in expected .venv location
+    cwd = Path.cwd()
+    expected_venv = cwd / ".venv"
+
+    # Platform-specific paths for venv Python
+    if sys.platform == "win32":
+        expected_python = expected_venv / "Scripts" / "python.exe"
+    else:
+        expected_python = expected_venv / "bin" / "python"
+
+    executable_in_venv = False
+    try:
+        executable_in_venv = executable.resolve() == expected_python.resolve()
+    except (OSError, RuntimeError):
+        # Handle case where paths can't be resolved
+        executable_in_venv = str(executable).startswith(str(expected_venv))
+
+    if not in_venv:
+        issues.append("⚠️  Not running in a virtual environment")
+        issues.append("   This may cause import errors if required packages are not installed")
+    elif not executable_in_venv:
+        issues.append(f"⚠️  Python executable is not in expected .venv location")
+        issues.append(f"   Expected: {expected_python}")
+        issues.append(f"   Actual:   {executable}")
+        issues.append("   You may be using a different virtual environment or system Python")
+    else:
+        print(f"✅ Running in virtual environment: {expected_venv}")
+
+    # Check Python version against basic requirements (will verify against pyproject.toml later)
+    if py_version.major < 3 or (py_version.major == 3 and py_version.minor < 12):
+        issues.append(f"⚠️  Python {py_version_str} is below minimum required version 3.12")
+    elif py_version.major == 3 and py_version.minor >= 14:
+        issues.append(f"⚠️  Python {py_version_str} is above maximum supported version (< 3.14)")
+    else:
+        print(f"✅ Python version {py_version_str} is in expected range (>=3.12, <3.14)")
+
+    # Check sys.prefix and base_prefix
+    print(f"\nEnvironment paths:")
+    print(f"  sys.prefix:      {sys.prefix}")
+    print(f"  sys.base_prefix: {sys.base_prefix}")
+    if in_venv:
+        print(f"  Virtual env:     {sys.prefix}")
+
+    if issues:
+        print("\n" + "!" * 70)
+        print("POTENTIAL ISSUES DETECTED:")
+        print("!" * 70)
+        for issue in issues:
+            print(issue)
+        print("\nRECOMMENDATION:")
+        print("  Run this script using: uv run python env_utils.py")
+        print("  Or activate the virtual environment first:")
+        if sys.platform == "win32":
+            print("    .venv\\Scripts\\activate")
+        else:
+            print("    source .venv/bin/activate")
+        print("!" * 70)
+
+    print()
+    return (len(issues) == 0, py_version, issues)
+
+
+# ========== EXTERNAL DEPENDENCY IMPORTS (with error handling) ==========
+try:
+    from dotenv import dotenv_values, load_dotenv
+    import tomllib
+    from importlib import metadata
+    from packaging.requirements import Requirement
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+    EXTERNAL_IMPORTS_AVAILABLE = True
+except ImportError as e:
+    EXTERNAL_IMPORTS_AVAILABLE = False
+    IMPORT_ERROR = e
+    print("=" * 70)
+    print("IMPORT ERROR DETECTED")
+    print("=" * 70)
+    print(f"Failed to import required package: {e}")
+    print()
+    print("This usually means you're running Python outside the virtual environment")
+    print("or the required packages are not installed.")
+    print()
+    print("SOLUTIONS:")
+    print("  1. Run using uv (recommended):")
+    print("       uv run python env_utils.py")
+    print()
+    print("  2. Activate the virtual environment first:")
+    if sys.platform == "win32":
+        print("       .venv\\Scripts\\activate")
+    else:
+        print("       source .venv/bin/activate")
+    print("     Then run:")
+    print("       python env_utils.py")
+    print()
+    print("  3. Install dependencies:")
+    print("       uv sync")
+    print("     or")
+    print("       pip install -r requirements.txt")
+    print("=" * 70)
+    print()
+
+
+def summarize_value(key: str, value: str, example_value: str = None) -> str:
+    """Return masked form for API keys, or full value for non-API keys.
+
+    Args:
+        key: The environment variable name
+        value: The current value
+        example_value: The example/placeholder value from example.env (optional)
+
+    Returns:
+        - For *API_KEY variables: masked form (****last4) unless it matches the example value
+        - For *API_KEY variables matching example: full value (to show it needs changing)
+        - For non-API_KEY variables: full value (not obscured)
+        - For boolean strings: lowercase boolean
+    """
     lower = value.lower()
     if lower in ("true", "false"):
         return lower
+
+    # Check if this is an API_KEY variable
+    is_api_key = key.endswith("API_KEY")
+
+    if not is_api_key:
+        # Non-API_KEY variables are never obscured
+        return value
+
+    # For API_KEY variables, show full value if it matches the example (needs changing)
+    if example_value and value == example_value:
+        return value
+
+    # Otherwise, obscure the API key
     return "****" + value[-4:] if len(value) > 4 else "****" + value
+
+def check_env_conflicts(env_file_path: str):
+    """Check for conflicts between system environment variables and .env file.
+
+    This detects when users have API_KEYs in their system environment that may
+    conflict with the ones they want to use from the .env file, since load_dotenv()
+    does not override existing environment variables by default.
+
+    Args:
+        env_file_path: Path to the .env file
+    """
+    if not os.path.exists(env_file_path):
+        return
+
+    # Parse the .env file to get what values SHOULD be loaded
+    from dotenv import dotenv_values
+    env_file_vars = dotenv_values(env_file_path)
+
+    conflicts = []
+    for key, file_value in env_file_vars.items():
+        # Check if this key already exists in the environment
+        sys_value = os.environ.get(key)
+        if sys_value is not None and sys_value != file_value:
+            # There's a conflict - system env var exists and differs from .env file
+            conflicts.append({
+                'key': key,
+                'system_value': sys_value,
+                'file_value': file_value
+            })
+
+    if conflicts:
+        print("=" * 70)
+        print("⚠️  ENVIRONMENT VARIABLE CONFLICTS DETECTED")
+        print("=" * 70)
+        print("The following environment variables are already set in your system")
+        print("environment and differ from your .env file. Since load_dotenv()")
+        print("does not override existing variables, the system values will be used,")
+        print("which may not be what you intended.")
+        print()
+        for conflict in conflicts:
+            key = conflict['key']
+            print(f"Variable: {key}")
+            if key.endswith('API_KEY'):
+                # Obscure API keys in the output
+                sys_val = "****" + conflict['system_value'][-4:] if len(conflict['system_value']) > 4 else "****"
+                file_val = "****" + conflict['file_value'][-4:] if len(conflict['file_value']) > 4 else "****"
+                print(f"  System value: {sys_val}")
+                print(f"  .env value:   {file_val}")
+            else:
+                print(f"  System value: {conflict['system_value']}")
+                print(f"  .env value:   {conflict['file_value']}")
+            print()
+
+        print("SOLUTIONS:")
+        print("  1. Unset the conflicting system environment variables:")
+        if sys.platform == "win32":
+            print("     CMD:")
+            for conflict in conflicts:
+                print(f"       set {conflict['key']}=")
+            print("     PowerShell:")
+            for conflict in conflicts:
+                print(f"       Remove-Item Env:\\{conflict['key']}")
+        else:
+            for conflict in conflicts:
+                print(f"       unset {conflict['key']}")
+        print()
+        print("  2. Use load_dotenv(override=True) in your notebooks to force")
+        print("     .env values to take precedence")
+        print()
+        print("  3. Update your .env file to match your system environment")
+        print("=" * 70)
+        print()
+
 
 def check_manual_installs(file_path: str):
     """Check if manually installed applications are available in PATH.
@@ -75,6 +303,7 @@ def doublecheck_env(file_path: str):
 
     # Parse the example file to identify required keys and their example values
     required_keys = {}
+    all_example_values = {}
     with open(file_path, 'r') as f:
         lines = f.readlines()
         is_required_section = False
@@ -92,6 +321,12 @@ def doublecheck_env(file_path: str):
             elif '=' in stripped and not stripped.startswith('#'):
                 key = stripped.split('=')[0].strip()
                 value = stripped.split('=', 1)[1].strip()
+                # Remove quotes if present
+                if value.startswith("'") and value.endswith("'"):
+                    value = value[1:-1]
+                elif value.startswith('"') and value.endswith('"'):
+                    value = value[1:-1]
+                all_example_values[key] = value
                 if is_required_section:
                     required_keys[key] = value
 
@@ -99,20 +334,55 @@ def doublecheck_env(file_path: str):
     parsed = dotenv_values(file_path)
     issues = []
 
+    print("Environment Variables:")
+    printed_keys = set()
+
     for key in parsed.keys():
         current = os.getenv(key)
+        example_val = all_example_values.get(key)
+
         if current is not None:
-            print(f"{key}={summarize_value(current)}")
+            # Use the new summarize_value with key, value, and example_value
+            print(f"{key}={summarize_value(key, current, example_val)}")
 
             # Check if this required key still has the example/placeholder value
             if key in required_keys:
-                example_val = required_keys[key]
                 if current == example_val:
                     issues.append(f"  ⚠️  {key} still has the example/placeholder value")
         else:
             print(f"{key}=<not set>")
             if key in required_keys:
                 issues.append(f"  ⚠️  {key} is required but not set")
+
+        printed_keys.add(key)
+
+    # Check for any additional uncommented variables in .env that weren't in example.env
+    actual_env_file = ".env"
+    if os.path.exists(actual_env_file):
+        actual_env_vars = dotenv_values(actual_env_file)
+        additional_vars = set(actual_env_vars.keys()) - printed_keys
+
+        if additional_vars:
+            print("\nAdditional variables in .env (not in example.env):")
+            for key in sorted(additional_vars):
+                current = os.getenv(key)
+                if current is not None:
+                    # No example value to compare against for additional vars
+                    print(f"{key}={summarize_value(key, current, None)}")
+                else:
+                    print(f"{key}=<not set>")
+
+    # Special check for LangSmith tracing
+    langsmith_tracing = os.getenv("LANGSMITH_TRACING", "").lower()
+    langsmith_api_key = os.getenv("LANGSMITH_API_KEY", "")
+    langsmith_example = all_example_values.get("LANGSMITH_API_KEY", "")
+
+    if langsmith_tracing == "true":
+        # Check if API key is missing, empty, or still has the example value
+        if not langsmith_api_key:
+            issues.append(f"  ⚠️  LANGSMITH_TRACING is enabled but LANGSMITH_API_KEY is not set")
+        elif langsmith_api_key == langsmith_example:
+            issues.append(f"  ⚠️  LANGSMITH_TRACING is enabled but LANGSMITH_API_KEY still has the example/placeholder value")
 
     # Print any issues found
     if issues:
@@ -167,14 +437,6 @@ def check_venv(expected_venv_path: str = ".venv"):
 
 # ========== utility to check packages and python based on pyproject.toml  =====================================
 
-# Requires: pip install packaging
-import sys, tomllib
-from pathlib import Path
-from importlib import metadata
-from packaging.requirements import Requirement
-from packaging.specifiers import SpecifierSet
-from packaging.version import Version
-
 def _fmt_row(cols, widths):
     return " | ".join(str(c).ljust(w) for c, w in zip(cols, widths))
 
@@ -224,14 +486,30 @@ def doublecheck_pkgs(pyproject_path="pyproject.toml", verbose=False):
             except Exception:
                 rec["path"] = "(unknown)"
 
-            if spec not in ("(any)", "(unparsed)") and any(op in spec for op in "<>="):
-                sset = SpecifierSet(spec)
-                if Version(installed_ver) in sset:
-                    rec["status"] = "✅ OK"
+            # Check if package is in correct Python version's site-packages
+            expected_py_version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+            path_str = str(rec["path"]).lower()
+
+            # Check for version mismatch in path (if path contains a python version)
+            wrong_version = False
+            if "python" in path_str and rec["path"] != "(unknown)":
+                # Look for patterns like python3.11, python3.13, etc. that don't match current version
+                py_versions_in_path = re.findall(r'python\d+\.\d+', path_str)
+                if py_versions_in_path:
+                    # If we found python version(s) in path, check if any match current version
+                    if expected_py_version.lower() not in py_versions_in_path:
+                        wrong_version = True
+                        rec["status"] = "⚠️ Wrong Python version"
+
+            if not wrong_version:
+                if spec not in ("(any)", "(unparsed)") and any(op in spec for op in "<>="):
+                    sset = SpecifierSet(spec)
+                    if Version(installed_ver) in sset:
+                        rec["status"] = "✅ OK"
+                    else:
+                        rec["status"] = "⚠️ Version mismatch"
                 else:
-                    rec["status"] = "⚠️ Version mismatch"
-            else:
-                rec["status"] = "✅ OK"
+                    rec["status"] = "✅ OK"
 
         except metadata.PackageNotFoundError:
             # keep defaults: installed "-", status "❌ Missing"
@@ -272,8 +550,28 @@ def doublecheck_pkgs(pyproject_path="pyproject.toml", verbose=False):
 
 
 if __name__ == "__main__":
+    # Run early diagnostics FIRST (uses only standard library)
+    success, py_version, issues = check_python_executable_and_version()
+
+    # If external imports failed, exit with helpful message
+    if not EXTERNAL_IMPORTS_AVAILABLE:
+        print("Cannot proceed with full environment check due to missing dependencies.")
+        print("Please follow the solutions above to fix the import errors.")
+        sys.exit(1)
+
+    # Proceed with remaining checks (require external dependencies)
     check_venv()
     check_manual_installs("example.env")
+
+    # Check for environment conflicts BEFORE loading .env file
+    # This detects when system env vars will override .env file values
+    check_env_conflicts(".env")
+
+    # Load environment variables from .env file
     load_dotenv()
+
+    # Check environment variables and API keys
     doublecheck_env("example.env")
+
+    # Check packages
     doublecheck_pkgs(pyproject_path="pyproject.toml", verbose=True)

--- a/env_utils.py
+++ b/env_utils.py
@@ -224,7 +224,9 @@ def check_env_conflicts(env_file_path: str):
             print()
 
         print("SOLUTIONS:")
-        print("  1. Unset the conflicting system environment variables:")
+        print("  1. Do nothing and accept the system environment variable value.")
+        print()
+        print("  2. Unset the conflicting system environment variables for this shell session:")
         if sys.platform == "win32":
             print("     CMD:")
             for conflict in conflicts:
@@ -236,10 +238,10 @@ def check_env_conflicts(env_file_path: str):
             for conflict in conflicts:
                 print(f"       unset {conflict['key']}")
         print()
-        print("  2. Use load_dotenv(override=True) in your notebooks to force")
+        print("  3. Use load_dotenv(override=True) in your notebooks to force")
         print("     .env values to take precedence")
         print()
-        print("  3. Update your .env file to match your system environment")
+        print("  4. Update your .env file or shell init so the values are in agreement")
         print("=" * 70)
         print()
 
@@ -383,6 +385,10 @@ def doublecheck_env(file_path: str):
             issues.append(f"  ⚠️  LANGSMITH_TRACING is enabled but LANGSMITH_API_KEY is not set")
         elif langsmith_api_key == langsmith_example:
             issues.append(f"  ⚠️  LANGSMITH_TRACING is enabled but LANGSMITH_API_KEY still has the example/placeholder value")
+        else:
+            print("\n✅ LANGSMITH_TRACING is enabled and the LANGSMITH_API_KEY is set")
+    elif langsmith_api_key and langsmith_api_key != langsmith_example:
+        issues.append("⚠️  LANGSMITH_API_KEY is set, but LANGSMITH_TRACING is disabled")
 
     # Print any issues found
     if issues:


### PR DESCRIPTION
The check script now performs additional verifications.
verify the python executable is located within the venv and agrees with PATH
verify the python version and python lib versions are in agreement
verify no conflict between pre-defined env keys and keys in .env file
verify if langsmith tracing is true must also define langsmith api key
only obscure API_KEY vars and only if not equal to preset values
implement and test for both macOS and Windows11
