### PR TITLE
Fix uploaded file retrieval method in notebook

### DIFF
--- a/notebooks/module-1/1.4_multimodal_messages.ipynb
+++ b/notebooks/module-1/1.4_multimodal_messages.ipynb
@@ -105,7 +105,7 @@
     "import base64\n",
     "\n",
     "# Get the first (and only) uploaded file dict\n",
-    "uploaded_file = uploader.value[0]\n",
+    "uploaded_file = list(uploader.value.values())[0]\n",
     "\n",
     "# This is a memoryview\n",
     "content_mv = uploaded_file[\"content\"]\n",


### PR DESCRIPTION
we  must access it by key, not index.
uploaded_file = list(uploaded_files.values())[0]
instead of 
uploaded_file = uploader.value[0]
KeyError: 0