### PR TITLE
Internal User Demo is missing here

### DIFF
--- a/notebooks/module-3/3.4_dynamic_tools.ipynb
+++ b/notebooks/module-3/3.4_dynamic_tools.ipynb
@@ -116,12 +116,31 @@
     "\n",
     "response = agent.invoke(\n",
     "    {\"messages\": [HumanMessage(content=\"How many artists are in the database?\")]},\n",
+    "    context={\"user_role\": \"internal\"}\n",
+    ")\n",
+    "\n",
+    "print(response[\"messages\"][-1].content)"
+   ]
+  },
+
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9833e543",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.messages import HumanMessage\n",
+    "\n",
+    "response = agent.invoke(\n",
+    "    {\"messages\": [HumanMessage(content=\"How many artists are in the database?\")]},\n",
     "    context={\"user_role\": \"external\"}\n",
     ")\n",
     "\n",
     "print(response[\"messages\"][-1].content)"
    ]
   },
+
   {
    "cell_type": "code",
    "execution_count": null,


### PR DESCRIPTION
from langchain.messages import HumanMessage

response = agent.invoke(
    {"messages": [HumanMessage(content="How many artists are in the database?")]},
    context={"user_role": "internal"}
)

print(response["messages"][-1].content)
Result
There are 275 artists in the database.