### PR TITLE
Refactor email agent response handling logic

### DIFF
--- a/notebooks/module-3/3.5_email_agent.ipynb
+++ b/notebooks/module-3/3.5_email_agent.ipynb
@@ -206,7 +206,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(response['__interrupt__'][0].value['action_requests'][0]['args']['body'])"
+    "if "__interrupt__" in response:
+    print(response["__interrupt__"])
+else:
+    print(response["messages"][-1].content)"
    ]
   },
   {


### PR DESCRIPTION
1. What your code expects vs what you actually have Your failing line
print(response['__interrupt__'][0].value['action_requests'][0]['args']['body'])


This line assumes all of the following exist:

A top-level key called __interrupt__

Inside it, a list

Each item has .value

Inside .value, there is action_requests

Inside that, args['body']

None of that exists in your actual response.

2. What the response actually contains

Your printed response is:

{
  'messages': [
      AIMessage(...),
      HumanMessage(...),
      AIMessage(...)
  ]
}


Key observations:

No __interrupt__ key

No action_requests

No tool calls

This is a plain conversational response

The content you want is inside AIMessage.content

This response came from:

model="gpt-5-nano"

No tools

No interrupt-driven agent loop

So your code is trying to read agent-execution metadata from a normal chat response.

3. Why __interrupt__ does not exist

__interrupt__ appears only when ALL of these are true:

You are using a graph / agent executor

The agent is configured with interrupt points

A tool call or action is paused for human input

The framework explicitly injects __interrupt__

Your current run:

Uses plain invoke()

No tools

No graph

No interrupt configuration

So the key never gets created.

This is expected behavior.

4. Correct way to extract the text you want (immediate fix) If your goal is to read the model’s output text

Use this instead:

last_ai_message = response["messages"][-1]
print(last_ai_message.content)


This will output:

Here’s Draft 1 for a sign-in prompt/text...


That is the only valid payload in this response.

5. Defensive access pattern (recommended)

If you are experimenting and want to avoid crashes:

if "__interrupt__" in response:
    print(response["__interrupt__"])
else:
    print(response["messages"][-1].content)


This lets the same notebook work for:

Chat-only calls

Agent calls

Interrupt-based flows

6. If your real intention was to capture tool / action requests

Then you must change how the agent is built, not how you read the response.

You would need:

A tool-enabled agent

A graph or executor that supports interrupts

A run where the model actually requests an action

Example conceptual flow:

User → Agent
Agent → “I need to call a tool”
Framework → __interrupt__
Human/Code → supplies tool result
Agent → continues


Without this setup, __interrupt__ will never appear.

7. Mental model to remember (important) Situation	Where the output lives
Plain chat model	response["messages"][-1].content
Tool call	AIMessage.tool_calls
Agent interrupt	response["__interrupt__"]
LangGraph state	state["messages"]

You mixed agent-internal plumbing with a chat-only response.