### PR TITLE
fix: patch 2 medium/low-severity security alerts (Pygments, prismjs)

### DIFF
--- a/notebooks/module-3/agent-chat-ui/package.json
+++ b/notebooks/module-3/agent-chat-ui/package.json
@@ -87,7 +87,8 @@
   "pnpm": {
     "overrides": {
       "playwright": ">=1.55.1",
-      "@playwright/test": ">=1.55.1"
+      "@playwright/test": ">=1.55.1",
+      "prismjs": ">=1.30.0"
     }
   },
   "packageManager": "pnpm@10.5.1"

--- a/notebooks/module-3/agent-chat-ui/pnpm-lock.yaml
+++ b/notebooks/module-3/agent-chat-ui/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   playwright: '>=1.55.1'
   '@playwright/test': '>=1.55.1'
+  prismjs: '>=1.30.0'
 
 importers:
 
@@ -2996,10 +2997,6 @@ packages:
     resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
     peerDependencies:
       react: '>=16.0.0'
-
-  prismjs@1.27.0:
-    resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
-    engines: {node: '>=6'}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -6542,8 +6539,6 @@ snapshots:
       clsx: 2.1.1
       react: 19.1.0
 
-  prismjs@1.27.0: {}
-
   prismjs@1.30.0: {}
 
   prop-types@15.8.1:
@@ -6677,7 +6672,7 @@ snapshots:
     dependencies:
       hastscript: 6.0.0
       parse-entities: 2.0.0
-      prismjs: 1.27.0
+      prismjs: 1.30.0
 
   regexp.prototype.flags@1.5.4:
     dependencies:

--- a/uv.lock
+++ b/uv.lock
@@ -2737,11 +2737,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Security Alert Patch

Resolves 2 Dependabot security alerts in the **medium + low** severity tier.

### Packages Updated

| Package | Old Constraint | New Constraint | Strategy | Scope | CVEs Resolved |
|---------|---------------|----------------|----------|-------|---------------|
| Pygments | 2.19.2 | 2.20.0 | A — direct bump via `uv lock --upgrade-package Pygments` | runtime (via `rich`, `ipython-pygments-lexers`) | CVE-2026-4539 |
| prismjs | 1.27.0 | removed from lockfile (1.30.0 now sole version) | C — pnpm override `>=1.30.0`; eliminates vulnerable 1.27.0 pulled in by `refractor@3.6.0` → `react-syntax-highlighter` | dev-only (private app, not published) | CVE-2024-53382 |

Strategy = direct bump (A) / parent bump (B) / override (C, dev-only)
Scope = runtime (installed dependency chain) / dev-only (private app, not published to npm)

### CVE Details

| CVE | GHSA | Package | Summary |
|-----|------|---------|---------|
| CVE-2026-4539 | GHSA-5239-wwwm-4pmq | Pygments | ReDoS via inefficient regex for GUID matching (< 2.20.0) |
| CVE-2024-53382 | GHSA-x7hr-w5r2-h6wg | prismjs | DOM Clobbering vulnerability (< 1.30.0) |

### Linear Tickets

No matching Linear tickets found.

### Verification

- [x] `uv lock` regenerated (`pygments` 2.19.2 → 2.20.0)
- [x] `pnpm install` regenerated (`prismjs@1.27.0` eliminated, only `1.30.0` remains)
- [x] Linters pass for changed files (pre-existing ruff/eslint/prettier issues in source files unrelated to this fix)
- [x] No tests in repo to run

🤖 Submitted by langster-patch