### PR TITLE
updated sonnet-4-5 and gemini-2.5-flash-lite

### DIFF
--- a/notebooks/module-1/1.1_foundational_models.ipynb
+++ b/notebooks/module-1/1.1_foundational_models.ipynb
@@ -114,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = init_chat_model(model=\"claude-sonnet-4-5\")\n",
+    "model = init_chat_model(model=\"claude-sonnet-4-6\")\n",
     "\n",
     "response = model.invoke(\"What's the capital of the Moon?\")\n",
     "print(response.content)"
@@ -129,7 +129,7 @@
    "source": [
     "from langchain_google_genai import ChatGoogleGenerativeAI\n",
     "\n",
-    "model = ChatGoogleGenerativeAI(model=\"gemini-2.5-flash-lite\")\n",
+    "model = ChatGoogleGenerativeAI(model=\"gemini-3.1-flash-lite\")\n",
     "\n",
     "response = model.invoke(\"What's the capital of the Moon?\")\n",
     "print(response.content)"
@@ -162,7 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = create_agent(model=\"claude-sonnet-4-5\")"
+    "agent = create_agent(model=\"claude-sonnet-4-6\")"
    ]
   },
   {
@@ -281,7 +281,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/module-3/3.4_dynamic_models.ipynb
+++ b/notebooks/module-3/3.4_dynamic_models.ipynb
@@ -23,7 +23,7 @@
     "from langchain.chat_models import init_chat_model\n",
     "from typing import Callable\n",
     "\n",
-    "large_model = init_chat_model(\"claude-sonnet-4-5\")\n",
+    "large_model = init_chat_model(\"claude-sonnet-4-6\")\n",
     "standard_model = init_chat_model(\"gpt-5-nano\")\n",
     "\n",
     "\n",
@@ -139,7 +139,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -153,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The models sonnet-4-5 and gemini-2.5-flash-lite are scheduled to be retired on 9/29 and 10/16 respectively.  Updated sonnet to 4-6 and gemini to 3.1-flash-lite.